### PR TITLE
json_last_error_msg support for older php versions

### DIFF
--- a/init.php
+++ b/init.php
@@ -522,3 +522,36 @@ class Feediron extends Plugin implements IHandler
 	   }
 	}
 }
+
+
+/*
+	json_last_error_msg requires php >= 5.5.0 see http://php.net/manual/en/function.json-last-error-msg.php
+	a possible fix would be:
+*/
+
+if (!function_exists('json_last_error_msg'))
+{
+    function json_last_error_msg()
+    {
+        switch (json_last_error()) {
+            default:
+                return;
+            case JSON_ERROR_DEPTH:
+                $error = 'Maximum stack depth exceeded';
+            break;
+            case JSON_ERROR_STATE_MISMATCH:
+                $error = 'Underflow or the modes mismatch';
+            break;
+            case JSON_ERROR_CTRL_CHAR:
+                $error = 'Unexpected control character found';
+            break;
+            case JSON_ERROR_SYNTAX:
+                $error = 'Syntax error, malformed JSON';
+            break;
+            case JSON_ERROR_UTF8:
+                $error = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+            break;
+        }
+        throw new Exception($error);
+    }
+}


### PR DESCRIPTION
as described in the  commit message: php <5.5.0 get an errormessage when trying to use this plugin
