### PR TITLE
Throwing an exception in the plugin is not that good of an idea

### DIFF
--- a/init.php
+++ b/init.php
@@ -552,6 +552,6 @@ if (!function_exists('json_last_error_msg'))
                 $error = 'Malformed UTF-8 characters, possibly incorrectly encoded';
             break;
         }
-        throw new Exception($error);
+        return $error;
     }
 }


### PR DESCRIPTION
War vielleicht keine gute Idee eine Exception zu werfen, wunderte mich, dass im Fehlerfall keine Meldung sondern ein HTTP 500 als Serverantwort kam.

Damit sollten auch viele Fragen im Forum erledigt sein, die wissen wollen weshalb, trotz Speicherung keine Änderungen da sind...
