### PR TITLE
New recipes for heise.de feeds: newsticker, developer, tr, and tp

### DIFF
--- a/recipes/heise_de_developer
+++ b/recipes/heise_de_developer
@@ -1,0 +1,19 @@
+{
+	"name": "heise.de Developer",
+	"url": "http://www.heise.de/developer/",
+	"match": "heise.de\/developer",
+	"author": "phbaer",
+	"config": {
+		"type": "xpath",
+		"xpath": "article",
+		"cleanup": [
+			"p[contains(@class,'news_datum')]",
+			"div[contains(@class,'readspeakerr')]",
+			"h1[contains(@class,'clear')]",
+			"noscript",
+			"comment()",
+			"script",
+			"footer"
+		]
+	}
+}

--- a/recipes/heise_de_newsticker
+++ b/recipes/heise_de_newsticker
@@ -1,0 +1,18 @@
+{
+	"name": "heise.de Newsticker",
+	"url": "http://www.heise.de/newsticker/",
+	"match": "heise.de",
+	"author": "phbaer",
+	"config": {
+		"type": "xpath",
+		"xpath": "article",
+		"cleanup": [
+			"p[contains(@class,'news_datum')]",
+			"div[contains(@class,'readspeakerr')]",
+			"h1[contains(@class,'clear')]",
+			"noscript",
+			"comment()",
+			"script"
+		]
+	}
+}

--- a/recipes/heise_de_technology_review
+++ b/recipes/heise_de_technology_review
@@ -1,0 +1,21 @@
+{
+	"name": "heise.de Technology Review",
+	"url": "http://www.heise.de/tr/",
+	"match": "heise.de\/tr",
+	"author": "phbaer",
+	"config": {
+		"type": "xpath",
+		"xpath": "div[@id='mitte_links']",
+		"multipage": {
+			"xpath": "a[contains(@class, 'seite_weiter')]",
+			"append": true
+		},
+		"cleanup": [
+			"ul[@class='optionen_beitrag']",
+			"p[@class='ausgabe']",
+			"p[@class='printversion']",
+			"p[@class='permalink']",
+			"nav[@class='pagenavi']"
+		]
+	}
+}

--- a/recipes/heise_de_telepolis
+++ b/recipes/heise_de_telepolis
@@ -1,0 +1,23 @@
+{
+	"name": "heise.de Telepolis",
+	"url": "http://www.heise.de/tp/",
+	"match": "heise.de\/tp",
+	"author": "phbaer",
+	"config":{
+		"type": "xpath",
+		"xpath": "div[contains(@class, 'artikel')]",
+		"multipage": {
+			"xpath": "a[@rel='next' and text()='N\u00e4chste Seite']",
+			"append": true,
+			"recursive": true
+		},
+		"cleanup": [
+			"div[@id='theodor']",
+			"p[contains(@class, 'np')]",
+			"div[@id='tp-bottomleiste-nt']",
+			"p[@class='vp-top']",
+			"p[@class='vp-bottom']",
+			"h4[@class='hnp']"
+		]
+	}
+}


### PR DESCRIPTION
Just some old but extended -- remove footer for heise.de/(newsticker|tr) -- and some new -- heise.de/(developer|tp) -- recipes for FeedIron. First preliminary versions.