### PR TITLE
Prevent warning Use of undefined constant LOG_NONE

### DIFF
--- a/Logger.php
+++ b/Logger.php
@@ -15,7 +15,7 @@ class Feediron_Logger{
 		return self::$logger;
 	}
 
-	private $loglevel = LOG_NONE;
+	private $loglevel = self::LOG_NONE;
 	private $testlog = array();
 	private $time_measure = false;
 


### PR DESCRIPTION
Use of undefined constant LOG_NONE - assumed 'LOG_NONE' (this will throw an Error in a future version of PHP)
1. plugins/feediron/Logger.php(12): ttrss_error_handler(2, Use of undefined constant LOG_NONE - assumed 'LOG_NONE' (this will throw an Error in a future version of PHP), plugins/feediron/Logger.php, 12, Array)
2. plugins/feediron/RecipeManager.php(14): get()
3. plugins/feediron/PrefTab.php(7): loadAvailableRecipes()
4. plugins/feediron/init.php(581): get_pref_tab({...}, false)
5. backend.php(123): index()