### PR TITLE
Add Readability.php optionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-ttrss_plugin-feediron
-=======================
+# ttrss_plugin-feediron
 
 This is a plugin for Tiny Tiny RSS (tt-rss). It allows you to replace an article's contents by the contents of an element on the linked URL's page, i.e. create a "full feed".
 
 
-Installation
-------------
+## Installation
 
 Checkout the directory into your plugins folder like this (from tt-RSS root directory):
 
@@ -16,9 +14,17 @@ $ git clone git://github.com/m42e/ttrss_plugin-feediron.git plugins/feediron
 
 Then enable the plugin in preferences.
 
+### Optional
 
-Configuration
--------------
+Install [Readability.php](https://github.com/andreskrey/readability.php) using [composer](https://getcomposer.org/). Assuming composer is installed, navigate to the feeiron plugin folder with `composer.json` present and run:
+
+```
+$ composer install
+```
+
+___
+
+## Configuration
 
 The configuration is done in JSON format. In the preferences, you'll find a new tab called *FeedIron*. Use the large field to enter/modify the configuration data and click the **Save** button to store it.
 You can enter an URL in the field below and click **Test** to get a preview what the result will be if the filter is applied to the url. *Note:* Save before you test :).
@@ -140,8 +146,96 @@ The **steps** value is an array of actions performed in the given order. If **af
 
 There is an additional option **cleanup** available. Its an array of regex that are removed using preg_replace.
 
-### readability
-This option makes use of [php-readability]( https://github.com/j0k3r/php-readability ) which is a fork of the [original](http://code.fivefilters.org/php-readability). All the extraction is performed within this module.
+### Readability
+The Readability modules are a automated method that attempts to isolate the relevant article text and images.
+
+<details>
+<summary>Basic Usage</summary>
+
+```
+{
+	"type":"readability"
+}
+```
+</details>
+
+#### PHP-Readability
+In built default, This option makes use of [php-readability]( https://github.com/j0k3r/php-readability ) which is a fork of the [original](http://code.fivefilters.org/php-readability). All the extraction is performed within this module and has no configuration options
+
+#### Readability.php
+Optionally installed via composer [Readability.php](https://github.com/andreskrey/readability.php) is a PHP port of Mozilla's Readability.js. All the extraction is performed within this module.
+
+<details>
+<summary>Advanced Usage</summary>
+
+#### Fix Relative URLS
+Convert relative URLs to absolute. Like `/test` to `http://host/test`
+```
+{
+	"type":"readability",
+	"relativeurl":"http:\/\/example.com\/"
+}
+```
+
+#### Remove ByLine from Article
+```
+{
+	"type":"readability",
+	"removebyline":true
+}
+```
+
+#### Normalize Page
+Default value `false`, converts UTF-8 characters to its HTML Entity equivalent. Useful to parse HTML with mixed encoding.
+```
+{
+	"type":"readability",
+	"normalize":true
+}
+```
+</details>
+
+<details>
+<summary>Advanced Usage: Article Images</summary>
+
+#### Prepened Main Image
+Default value `false`, returns the main image of the article Prepended before the article.
+```
+{
+	"type":"readability",
+	"prependimage":true
+}
+```
+
+#### Main Image Only
+Default value `false`, returns the main image of the article.
+```
+{
+	"type":"readability",
+	"mainimage":true
+}
+```
+
+#### Append All Images
+Default value `false`, returns all images in article appended after the article.
+```
+{
+	"type":"readability",
+	"appendimages":true
+}
+```
+
+#### All Images Only
+Default value `false`, returns all images in article without the article.
+```
+{
+	"type":"readability",
+	"allimages":true
+}
+```
+
+
+</details>
 
 ## multipage
 This option indicates that the article is split into two or more pages (eventually). FeedIron can combine all the parts into the content of the article.
@@ -152,8 +246,8 @@ the fetching stops if an url is added twice.
 ### General options
 * **debug** You can activate debugging informations.  (At the moment there are not that much debug informations to be activated), this option must be places at the same level as the site configs.
 * **force_charset** allows to override automatic charset detection. If it is omitted, the charset will be parsed from the HTTP headers or loadHTML() will decide on its own.  
-* **reformat** is an array of formating rules for the **url** of the full article. The rules are applied before the full article is fetched. There are two possible types: **regex** and **replace**. 
-  * **regex** takes a regex in an option called **pattern** and the replacement in **replace**. For details see [preg_replace](http://www.php.net/manual/de/function.preg-replace.php) in the PHP documentation. 
+* **reformat** is an array of formating rules for the **url** of the full article. The rules are applied before the full article is fetched. There are two possible types: **regex** and **replace**.
+  * **regex** takes a regex in an option called **pattern** and the replacement in **replace**. For details see [preg_replace](http://www.php.net/manual/de/function.preg-replace.php) in the PHP documentation.
   * **replace** uses the PHP function str_replace, which takes either a string or an array as search and replace value.  
 * **modify** is the same as described above but for the content. It is applied after the split/xpath selection.
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "andreskrey/readability.php": "^1.1"
+    }
+}

--- a/init.php
+++ b/init.php
@@ -7,6 +7,13 @@ include "Json.php";
 include "User.php";
 include "PrefTab.php";
 
+//Load Composer autoloader hiding errors
+@include('vendor/autoload.php');
+
+//Load Readability.php
+use andreskrey\Readability\Readability as ReadabilityPHP;
+use andreskrey\Readability\Configuration as ReadabilityPHPConf;
+
 class Feediron extends Plugin implements IHandler
 {
 	private $host;
@@ -401,28 +408,91 @@ class Feediron extends Plugin implements IHandler
 	}
 
 	function performReadability($html, $config, $link){
-		Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Using Readability");
 
-		require_once 'php-readability/Readability.php';
-		require_once 'php-readability/JSLikeHTMLElement.php';
-		$readability = new Readability\Readability($html, $link);
-		$readability->debug = false;
-		$readability->convertLinksToFootnotes = true;
-		$result = $readability->init();
-		if (!$result) {
-			Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability failed to find content");
-			return $html;
-		}
-		else{
-			$content = $readability->getContent()->innerHTML;
-			// if we've got Tidy, let's clean it up for output
-			if (function_exists('tidy_parse_string')) {
-				$tidy = tidy_parse_string($content, array('indent'=>true, 'show-body-only' => true), 'UTF8');
-				$tidy->cleanRepair();
-				$content = $tidy->value;
+		if (class_exists(ReadabilityPHP::class)) {
+			Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Using Readability.php");
+
+			$configuration = new ReadabilityPHPConf();
+			if( isset( $config['relativeurl'] ) ) {
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability.php fixing relative URLS ".$config['relativeurl']);
+				$configuration
+					->setFixRelativeURLs( true )
+					->setOriginalURL( $config['relativeurl'] );
 			}
-			return $content;
+			if( isset( $config['normalize'] ) && is_bool( $config['normalize'] )  ) {
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability.php Normalizing content");
+				$configuration
+					->setNormalizeEntities( $config['normalize'] );
+			}
+			if( isset( $config['removebyline'] ) && is_bool( $config['removebyline'] )  ) {
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability.php Removing ByLine");
+				$configuration
+					->setArticleByLine( $config['removebyline'] );
+			}
+			//Load Readability with Configuration
+			$readability = new ReadabilityPHP( $configuration );
+
+			try {
+
+				$readability->parse($html);
+
+			} catch (Exception $e) {
+
+				//Return unmodified html if Readability.php fails
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Readability.php failed to find content");
+				return $html;
+
+			}
+			if( isset( $config['prependimage'] ) && ( $config['prependimage'] )  ) {
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability.php Prepending Main Image");
+				$image = $readability->getImage();
+				$content = '<img src="'.$image.'"></img>';
+				$content .= $readability->getContent();
+			}
+			elseif( isset( $config['mainimage'] ) && ( $config['mainimage'] )  ) {
+				$image = $readability->getImage();
+				$content = '<img src="'.$image.'"></img>';
+			}
+			elseif( isset( $config['appendimages'] ) && ( $config['apendimages'] )  ) {
+				$images = $readability->getImages();
+				$content = $readability->getContent();
+				foreach ( $images as $image ) {
+					$content.='<img src="'.$image.'"></img><br>';
+				}
+			}
+			elseif( isset( $config['allimages'] ) && ( $config['allimages'] )  ) {
+				$images = $readability->getImages();
+				foreach ( $images as $image ) {
+					$content.='<img src="'.$image.'"></img><br>';
+				}
+			} else {
+				$content = $readability->getContent();
+			}
 		}
+		else {
+			Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Using Legacy Readability");
+
+			require_once 'php-readability/Readability.php';
+			require_once 'php-readability/JSLikeHTMLElement.php';
+			$readability = new Readability\Readability($html, $link);
+			$readability->debug = false;
+			$readability->convertLinksToFootnotes = true;
+			$result = $readability->init();
+			if (!$result) {
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability failed to find content");
+				return $html;
+			}
+			else {
+				$content = $readability->getContent()->innerHTML;
+			}
+		}
+		// if we've got Tidy, let's clean it up for output
+		if (function_exists('tidy_parse_string')) {
+			$tidy = tidy_parse_string($content, array('indent'=>true, 'show-body-only' => true), 'UTF8');
+			$tidy->cleanRepair();
+			$content = $tidy->value;
+		}
+		return $content;
 
 	}
 
@@ -682,9 +752,9 @@ class Feediron extends Plugin implements IHandler
 		Feediron_Logger::get()->set_log_level($_POST['verbose']?Feediron_Logger::LOG_VERBOSE:Feediron_Logger::LOG_TEST);
 		$test_url = $_POST['test_url'];
 		Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Test url: $test_url");
-		
+
 		if(isset($_POST['test_conf']) && trim($_POST['test_conf']) != ''){
-			
+
 			$json_conf = $_POST['test_conf'];
 			$json_reply = array();
 			Feediron_Json::format($json_conf);
@@ -697,7 +767,7 @@ class Feediron extends Plugin implements IHandler
 				echo json_encode($json_reply);
 				return false;
 			}
-			
+
 			$config = $this->getConfigSection($test_url);
 			Feediron_Logger::get()->log_object(Feediron_Logger::LOG_TEST, "config found: ", $config);
 			$newconfig = json_decode($_POST['test_conf'], true);
@@ -738,4 +808,3 @@ class Feediron extends Plugin implements IHandler
 		}
 	}
 }
-


### PR DESCRIPTION
Adds the ability to use [readability.php](https://github.com/andreskrey/readability.php) if installed (via composer)
- [x] - Composer.json
- [x] - Fallback to php-readability
- [x] - Allow silent fail of autoloader.php
- [x] - Added install instructions to Readme + minor format alignment

Configuration options that would be good to implement:
- [x] - setFixRelativeURLs
- [x] - setOriginalURL
- [x] - getImage
- [x] - getImages