### PR TITLE
I need `start_element` and `end_element` in the "split" type

### DIFF
--- a/filters/fi_mod_split/README.md
+++ b/filters/fi_mod_split/README.md
@@ -41,8 +41,8 @@ String - Appends string to the end of content
 "example.com":{
   "type":"split",
   "steps":[{
-        "after": "/<head>\s*<title>/",
-        "before": "/</title>/"
+        "after": "/<head>\\s*<title>/",
+        "before": "/</"
       }
     ],
 	"start_element":"The Title is >",

--- a/filters/fi_mod_split/README.md
+++ b/filters/fi_mod_split/README.md
@@ -4,6 +4,8 @@
 	* [steps](#steps---steps-array-of-steps-) - `"steps":[ array of steps ]`
       * after - `"after":"str"`
       * before - `"before":"str"`
+	* [start_element](#start_element---start_elementstr) - `"start_element":"str"`
+	* [end_element](#end_element----end_elementstr) - `"end_element":"str"`
 	* [cleanup](#cleanup-cleanup-array-of-regex-) - `"cleanup":"/regex str/" / [ "/array of regex str/" ]`
 
 ## split - `"type":"split"`
@@ -24,6 +26,31 @@ The steps value is an array of actions performed in the given order. If after is
 ]
 }
 ```
+
+### Concatenation Elements
+
+#### start_element - `"start_element":"str"`
+String - Prepends string to the start of content
+
+#### end_element  - `"end_element":"str"`
+String - Appends string to the end of content
+
+**Full Example of Concatenation Elements:**
+
+```json
+"example.com":{
+  "type":"split",
+  "steps":[{
+        "after": "/<head>\s*<title>/",
+        "before": "/</title>/"
+      }
+    ],
+	"start_element":"The Title is >",
+	"end_element":"< The Title was"
+}
+```
+
+Result: `The Title is >Example Domain< The Title was`
 
 ### cleanup `"cleanup":[ "array of regex" ]`
 Optional - An array of regex that are removed using preg_replace.

--- a/filters/fi_mod_split/init.php
+++ b/filters/fi_mod_split/init.php
@@ -34,6 +34,19 @@ class fi_mod_split
         Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "cleanup  result", $html);
       }
     }
+
+	 #RJS: adding start/end elements
+    if(array_key_exists('start_element', $config)){
+      Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Adding start element", $config['start_element']);
+      $html = $config['start_element'].$html;
+    }
+
+    if(array_key_exists('end_element', $config)){
+      Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Adding end element", $config['end_element']);
+      $html = $html.$config['end_element'];
+    }
+	 #RJS: done
+
     return $html;
   }
 

--- a/filters/fi_mod_split/init.php
+++ b/filters/fi_mod_split/init.php
@@ -35,7 +35,6 @@ class fi_mod_split
       }
     }
 
-	 #RJS: adding start/end elements
     if(array_key_exists('start_element', $config)){
       Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Adding start element", $config['start_element']);
       $html = $config['start_element'].$html;
@@ -45,7 +44,6 @@ class fi_mod_split
       Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Adding end element", $config['end_element']);
       $html = $html.$config['end_element'];
     }
-	 #RJS: done
 
     return $html;
   }


### PR DESCRIPTION
# Bugfix/Enhancement

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

Fixes #

## Proposed Changes

I need the config actions `start_element` and `end_element` from the "xpath" type in the "split" type.  I copied the code from xpath to split.  I also updated the readme documentation to include the new elements with an example.  I copied heavily from the xpath readme, updated the example, and tested.  I am using this fork on my ttrss instance with great success.